### PR TITLE
Create custom http client for web

### DIFF
--- a/lib/src/kratos_client.dart
+++ b/lib/src/kratos_client.dart
@@ -12,6 +12,8 @@ import 'package:leancode_kratos_client/src/login/api/login_error.dart'
 import 'package:leancode_kratos_client/src/login/api/login_success.dart';
 import 'package:leancode_kratos_client/src/registration/api/registration_success.dart';
 import 'package:leancode_kratos_client/src/registration/api/token_exchange_success.dart';
+import 'package:leancode_kratos_client/src/utils/create_client.dart'
+    if (dart.library.js_interop) 'package:leancode_kratos_client/src/utils/create_browser_client.dart';
 import 'package:logging/logging.dart';
 
 typedef BrowserCallback = Future<String> Function(String url);
@@ -25,7 +27,7 @@ class KratosClient {
   })  : _baseUri = baseUri,
         _credentialsStorage =
             credentialsStorage ?? const FlutterSecureCredentialsStorage(),
-        _client = httpClient ?? http.Client();
+        _client = httpClient ?? createHttpClient();
 
   final Uri _baseUri;
   final CredentialsStorage _credentialsStorage;

--- a/lib/src/utils/create_browser_client.dart
+++ b/lib/src/utils/create_browser_client.dart
@@ -1,0 +1,6 @@
+import 'package:http/browser_client.dart';
+import 'package:http/http.dart';
+
+Client createHttpClient() {
+  return BrowserClient()..withCredentials = true;
+}

--- a/lib/src/utils/create_client.dart
+++ b/lib/src/utils/create_client.dart
@@ -1,0 +1,5 @@
+import 'package:http/http.dart';
+
+Client createHttpClient() {
+  return Client();
+}


### PR DESCRIPTION
I already implemented it in the example app where we have a custom client, but I believe that it should also be added at the library level.

Without `withCredentials` set to `true` credentials are not included when making requests (`false` by default).