### PR TITLE
Add KratosClient.getVerificationFlowById

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.0
+
+* **feat**: Add `KratosClient.getVerificationFlowById` for fetching an existing verification flow (e.g. one opened from a verification deep link) together with the e-mail address the code was sent to.
+
 ## 0.8.1
 
 * Remove `copy_with_extension` and `copy_with_extension_gen` dependencies.

--- a/documentation/verification.md
+++ b/documentation/verification.md
@@ -17,3 +17,19 @@ Send **code** obtained from e-mail via:
 ```dart
 final result = await client.verifyAccount(flowId: flowId, code: code)
 ```
+
+A verification deep link carries only the flow id and the code. To recover the
+rest of an existing flow — most importantly the e-mail address the code was
+sent to (e.g. to offer a "resend code" action after a cold start) — call:
+
+```dart
+final result = await client.getVerificationFlowById(flowId);
+```
+
+This returns a **GetVerificationFlowResult**:
+
+- `GetVerificationFlowSuccessResult` — carries `flowId`, the flow `state`, and
+  `email` (available once the flow has reached the `sentEmail` state),
+- `GetVerificationFlowNotFoundResult` — the flow does not exist,
+- `GetVerificationFlowExpiredResult` — the flow has expired,
+- `GetVerificationFlowUnknownErrorResult` — any other failure.

--- a/lib/leancode_kratos_client.dart
+++ b/lib/leancode_kratos_client.dart
@@ -20,6 +20,7 @@ export 'src/settings/domain/passkey.dart';
 export 'src/settings/domain/remove_passkey_result.dart';
 export 'src/utils/credentials_storage.dart';
 export 'src/utils/kratos_message.dart';
+export 'src/verification/domain/get_verification_flow_result.dart';
 export 'src/verification/domain/verification_result.dart';
 export 'src/whoami/domain/session_result.dart';
 export 'src/whoami/domain/session_validity_result.dart';

--- a/lib/leancode_kratos_client.dart
+++ b/lib/leancode_kratos_client.dart
@@ -21,6 +21,7 @@ export 'src/settings/domain/remove_passkey_result.dart';
 export 'src/utils/credentials_storage.dart';
 export 'src/utils/kratos_message.dart';
 export 'src/verification/domain/get_verification_flow_result.dart';
+export 'src/verification/domain/verification_flow_state.dart';
 export 'src/verification/domain/verification_result.dart';
 export 'src/whoami/domain/session_result.dart';
 export 'src/whoami/domain/session_validity_result.dart';

--- a/lib/src/common/api/verification_flow_dto.dart
+++ b/lib/src/common/api/verification_flow_dto.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:leancode_kratos_client/src/common/api/auth_dtos.dart';
@@ -37,6 +38,20 @@ class VerificationFlowDto with EquatableMixin {
   final UiDto ui;
 
   Map<String, dynamic> toJson() => _$VerificationFlowDtoToJson(this);
+
+  /// The address the flow's code was sent to, carried by the "resend code"
+  /// submit node. Present once the flow reaches the `sent_email` state; the
+  /// `email` node in `choose_method` is the input field and has no value.
+  String? get email =>
+      ui.nodes
+              .firstWhereOrNull(
+                (node) =>
+                    node.attributes.name == 'email' &&
+                    node.attributes.type == 'submit',
+              )
+              ?.attributes
+              .value
+          as String?;
 
   @override
   List<Object?> get props => [

--- a/lib/src/kratos_client.dart
+++ b/lib/src/kratos_client.dart
@@ -792,6 +792,44 @@ class KratosClient {
     }
   }
 
+  /// Fetches an existing verification flow by its id, e.g. one obtained from
+  /// a verification deep link. Does not require a session. Once the flow has
+  /// reached the `sent_email` state, the result carries the e-mail address the
+  /// code was sent to.
+  Future<GetVerificationFlowResult> getVerificationFlowById(
+    String flowId,
+  ) async {
+    try {
+      final response = await _client.get(
+        _buildUri(
+          path: 'self-service/verification/flows',
+          queryParameters: {'id': flowId},
+        ),
+        headers: _commonHeaders,
+      );
+
+      if (response.statusCode == 200) {
+        final flow = VerificationFlowDto.fromString(response.body);
+
+        return GetVerificationFlowSuccessResult(
+          flowId: flow.id,
+          state: VerificationFlowState.fromApiState(flow.state),
+          email: flow.email,
+        );
+      } else if (response.statusCode == 404) {
+        return const GetVerificationFlowNotFoundResult();
+      } else if (response.statusCode == 410) {
+        return const GetVerificationFlowExpiredResult();
+      }
+
+      return const GetVerificationFlowUnknownErrorResult();
+    } catch (err, st) {
+      _logger.warning('Error getting verification flow by id', err, st);
+
+      return const GetVerificationFlowUnknownErrorResult();
+    }
+  }
+
   Future<void> refreshSessionToken() async {
     final sessionToken = await _credentialsStorage.read();
     final expirationTime = await _credentialsStorage.readExpirationDate();

--- a/lib/src/verification/domain/get_verification_flow_result.dart
+++ b/lib/src/verification/domain/get_verification_flow_result.dart
@@ -1,3 +1,5 @@
+import 'package:leancode_kratos_client/src/verification/domain/verification_flow_state.dart';
+
 sealed class GetVerificationFlowResult {
   const GetVerificationFlowResult();
 }
@@ -10,7 +12,10 @@ final class GetVerificationFlowSuccessResult extends GetVerificationFlowResult {
   });
 
   final String flowId;
-  final VerificationFlowState state;
+
+  /// The state the flow is in, or `null` when it is one this package does not
+  /// know about.
+  final VerificationFlowState? state;
 
   /// The address the verification code was sent to. Available once the flow
   /// reaches [VerificationFlowState.sentEmail]; `null` before that.
@@ -30,18 +35,4 @@ final class GetVerificationFlowExpiredResult
 final class GetVerificationFlowUnknownErrorResult
     extends GetVerificationFlowResult {
   const GetVerificationFlowUnknownErrorResult();
-}
-
-enum VerificationFlowState {
-  chooseMethod,
-  sentEmail,
-  passedChallenge,
-  unknown;
-
-  static VerificationFlowState fromApiState(String state) => switch (state) {
-        'choose_method' => chooseMethod,
-        'sent_email' => sentEmail,
-        'passed_challenge' => passedChallenge,
-        _ => unknown,
-      };
 }

--- a/lib/src/verification/domain/get_verification_flow_result.dart
+++ b/lib/src/verification/domain/get_verification_flow_result.dart
@@ -1,0 +1,47 @@
+sealed class GetVerificationFlowResult {
+  const GetVerificationFlowResult();
+}
+
+final class GetVerificationFlowSuccessResult extends GetVerificationFlowResult {
+  const GetVerificationFlowSuccessResult({
+    required this.flowId,
+    required this.state,
+    this.email,
+  });
+
+  final String flowId;
+  final VerificationFlowState state;
+
+  /// The address the verification code was sent to. Available once the flow
+  /// reaches [VerificationFlowState.sentEmail]; `null` before that.
+  final String? email;
+}
+
+final class GetVerificationFlowNotFoundResult
+    extends GetVerificationFlowResult {
+  const GetVerificationFlowNotFoundResult();
+}
+
+final class GetVerificationFlowExpiredResult
+    extends GetVerificationFlowResult {
+  const GetVerificationFlowExpiredResult();
+}
+
+final class GetVerificationFlowUnknownErrorResult
+    extends GetVerificationFlowResult {
+  const GetVerificationFlowUnknownErrorResult();
+}
+
+enum VerificationFlowState {
+  chooseMethod,
+  sentEmail,
+  passedChallenge,
+  unknown;
+
+  static VerificationFlowState fromApiState(String state) => switch (state) {
+        'choose_method' => chooseMethod,
+        'sent_email' => sentEmail,
+        'passed_challenge' => passedChallenge,
+        _ => unknown,
+      };
+}

--- a/lib/src/verification/domain/verification_flow_state.dart
+++ b/lib/src/verification/domain/verification_flow_state.dart
@@ -1,0 +1,20 @@
+import 'package:collection/collection.dart';
+
+/// A stage of a Kratos verification flow.
+enum VerificationFlowState {
+  chooseMethod('choose_method'),
+  sentEmail('sent_email'),
+  passedChallenge('passed_challenge');
+
+  const VerificationFlowState(this.apiState);
+
+  /// The value Kratos uses in the flow's `state` field.
+  final String apiState;
+
+  /// The state a flow reports, or `null` when it is one this package does not
+  /// know about.
+  static VerificationFlowState? fromApiState(String state) =>
+      VerificationFlowState.values.firstWhereOrNull(
+        (flowState) => flowState.apiState == state,
+      );
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: >
   It helps manage user authentication, registration, making it simple to add identity features to your app.
 
 repository: https://github.com/leancodepl/leancode_kratos
-version: 0.8.1
+version: 0.9.0
 
 environment:
   sdk: ">=3.10.0 <4.0.0"

--- a/test/fixtures/get_verification_flow_fixture.dart
+++ b/test/fixtures/get_verification_flow_fixture.dart
@@ -53,3 +53,98 @@ const verificationFlowFixture = '''
     "state": "choose_method"
 }
 ''';
+
+const sentEmailVerificationFlowFixture = '''
+{
+    "id": "ed1efde6-8e5a-41df-93a9-caa7f76656ff",
+    "type": "api",
+    "expires_at": "2023-07-17T13:23:27.138051184Z",
+    "issued_at": "2023-07-17T12:23:27.138051184Z",
+    "request_url": "https://auth.leancode-internal-kratos.test.lncd.pl/self-service/verification/api",
+    "active": "code",
+    "ui": {
+        "action": "https://auth.leancode-internal-kratos.test.lncd.pl/self-service/verification?flow=ed1efde6-8e5a-41df-93a9-caa7f76656ff",
+        "method": "POST",
+        "nodes": [
+            {
+                "type": "input",
+                "group": "code",
+                "attributes": {
+                    "name": "method",
+                    "type": "hidden",
+                    "value": "code",
+                    "disabled": false,
+                    "node_type": "input"
+                },
+                "messages": [],
+                "meta": {}
+            },
+            {
+                "type": "input",
+                "group": "code",
+                "attributes": {
+                    "name": "code",
+                    "type": "text",
+                    "required": true,
+                    "disabled": false,
+                    "node_type": "input"
+                },
+                "messages": [],
+                "meta": {
+                    "label": {
+                        "id": 1070011,
+                        "text": "Verification code",
+                        "type": "info"
+                    }
+                }
+            },
+            {
+                "type": "input",
+                "group": "code",
+                "attributes": {
+                    "name": "method",
+                    "type": "submit",
+                    "value": "code",
+                    "disabled": false,
+                    "node_type": "input"
+                },
+                "messages": [],
+                "meta": {
+                    "label": {
+                        "id": 1070009,
+                        "text": "Continue",
+                        "type": "info"
+                    }
+                }
+            },
+            {
+                "type": "input",
+                "group": "code",
+                "attributes": {
+                    "name": "email",
+                    "type": "submit",
+                    "value": "email@email.com",
+                    "disabled": false,
+                    "node_type": "input"
+                },
+                "messages": [],
+                "meta": {
+                    "label": {
+                        "id": 1070008,
+                        "text": "Resend code",
+                        "type": "info"
+                    }
+                }
+            }
+        ],
+        "messages": [
+            {
+                "id": 1080003,
+                "text": "An email containing a verification code has been sent to the email address you provided.",
+                "type": "info"
+            }
+        ]
+    },
+    "state": "sent_email"
+}
+''';

--- a/test/kratos_test.dart
+++ b/test/kratos_test.dart
@@ -248,6 +248,122 @@ void main() {
     });
   });
 
+  group('get verification flow by id', () {
+    const flowId = 'ed1efde6-8e5a-41df-93a9-caa7f76656ff';
+
+    late MockCredentialsStorage mockStorage;
+    late KratosClient kratosClient;
+    late MockHttpClient mockHttpClient;
+
+    setUpAll(() {
+      registerFallbackValue(MockUri());
+    });
+
+    setUp(() {
+      mockHttpClient = MockHttpClient();
+      mockStorage = MockCredentialsStorage();
+      kratosClient = KratosClient(
+        baseUri: Uri(host: 'test.pl', scheme: 'https'),
+        credentialsStorage: mockStorage,
+        httpClient: mockHttpClient,
+      );
+    });
+
+    test('should return the flow with the email it was sent to', () async {
+      when(
+        () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+      ).thenAnswer(
+        (_) async => http.Response(sentEmailVerificationFlowFixture, 200),
+      );
+
+      final result = await kratosClient.getVerificationFlowById(flowId);
+
+      expect(
+        result,
+        isA<GetVerificationFlowSuccessResult>()
+            .having((result) => result.flowId, 'flowId', flowId)
+            .having(
+              (result) => result.state,
+              'state',
+              VerificationFlowState.sentEmail,
+            )
+            .having((result) => result.email, 'email', 'email@email.com'),
+      );
+
+      final uri =
+          verify(
+                () => mockHttpClient.get(
+                  captureAny(),
+                  headers: any(named: 'headers'),
+                ),
+              ).captured.single
+              as Uri;
+      expect(uri.path, '/self-service/verification/flows');
+      expect(uri.queryParameters['id'], flowId);
+    });
+
+    test(
+      'should return no email when the flow has not sent one yet',
+      () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response(verificationFlowFixture, 200));
+
+        final result = await kratosClient.getVerificationFlowById(flowId);
+
+        expect(
+          result,
+          isA<GetVerificationFlowSuccessResult>()
+              .having(
+                (result) => result.state,
+                'state',
+                VerificationFlowState.chooseMethod,
+              )
+              .having((result) => result.email, 'email', null),
+        );
+      },
+    );
+
+    test(
+      'should return GetVerificationFlowNotFoundResult when statusCode is 404',
+      () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response('', 404));
+
+        final result = await kratosClient.getVerificationFlowById(flowId);
+
+        expect(result, isA<GetVerificationFlowNotFoundResult>());
+      },
+    );
+
+    test(
+      'should return GetVerificationFlowExpiredResult when statusCode is 410',
+      () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response('', 410));
+
+        final result = await kratosClient.getVerificationFlowById(flowId);
+
+        expect(result, isA<GetVerificationFlowExpiredResult>());
+      },
+    );
+
+    test(
+      'should return GetVerificationFlowUnknownErrorResult on exception',
+      () async {
+        when(
+          () => mockHttpClient.get(any(), headers: any(named: 'headers')),
+        ).thenAnswer((_) async => http.Response('test', 200));
+
+        final result = await kratosClient.getVerificationFlowById(flowId);
+
+        expect(result, isA<GetVerificationFlowUnknownErrorResult>());
+      },
+    );
+  });
+
   group('Verify account', () {
     late MockCredentialsStorage mockStorage;
     late KratosClient kratosClient;


### PR DESCRIPTION
## Why

A verification deep link carries only the flow id and the code — not the e-mail address. An app cold-started from such a link cannot offer a working "resend code" action, because `getNewVerificationFlow` requires the address.

Kratos keeps the submitted address inside the flow itself: in the `sent_email` state, `ui.nodes` contains a `{name: "email", type: "submit", value: "<address>"}` node (the mechanism behind the "Resend code" button in Kratos' browser UI), and `GET /self-service/verification/flows?id=<flowId>` works without a session. Verified against a live Kratos instance.

## What

- `KratosClient.getVerificationFlowById(String flowId)` — fetches an existing verification flow by id, returning a new sealed `GetVerificationFlowResult`:
  - `GetVerificationFlowSuccessResult` with `flowId`, `state` (new `VerificationFlowState` enum) and `email` (available once the flow reached `sentEmail`)
  - `GetVerificationFlowNotFoundResult` (404), `GetVerificationFlowExpiredResult` (410), `GetVerificationFlowUnknownErrorResult`
- `VerificationFlowDto.email` getter extracting the address from the resend-code submit node (filtered by `type == 'submit'` so the `choose_method` input node is not misread)
- Tests for all result branches, docs section in `documentation/verification.md`, changelog + version bump to 0.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)